### PR TITLE
refactor: migrate faker to @faker-js/faker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "faker": "^5.5.3",
         "jest": "^28.1.3",
         "jest-junit": "^14.0.1",
         "jest-mock-extended": "^2.0.6",
@@ -2992,12 +2991,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
-      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "json-stream",
-  "version": "1.0.0",
+  "name": "json-stream-watcher",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "json-stream",
-      "version": "1.0.0",
+      "name": "json-stream-watcher",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.7.0",
-        "@faker-js/faker": "^7.5.0",
+        "@faker-js/faker": "^9.6.0",
         "@types/eslint__js": "^8.42.3",
         "@types/faker": "^5.5.3",
         "@types/jest": "^29.0.0",
@@ -670,13 +670,20 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.6.0.tgz",
+      "integrity": "sha512-3vm4by+B5lvsFPSyep3ELWmZfE3kicDtmemVpuwl1yH7tqtnHdsA6hG8fbXedMVdkzgtvzWoRgjSB4Q+FHnZiw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "faker": "^5.5.3",
     "jest": "^28.1.3",
     "jest-junit": "^14.0.1",
     "jest-mock-extended": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.7.0",
-    "@faker-js/faker": "^7.5.0",
+    "@faker-js/faker": "^9.6.0",
     "@types/eslint__js": "^8.42.3",
     "@types/faker": "^5.5.3",
     "@types/jest": "^29.0.0",

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -1,12 +1,12 @@
-import faker from 'faker'
+import { faker } from '@faker-js/faker'
 import { JSONStream } from './json-stream'
 
 const createBigArrayObject = (size: number) => {
   const arr = []
   for (let i = 0; i < size; i++) {
     arr.push({
-      name: faker.name.firstName(),
-      age: faker.datatype.number({ min: 10, max: 70 }),
+      name: faker.person.firstName(),
+      age: faker.number.int({ min: 10, max: 70 }),
       description: faker.lorem.paragraph(),
     })
   }
@@ -25,7 +25,7 @@ describe('JSONStream performance', () => {
     let index = 0
 
     while (index < bigJson.length) {
-      const chunkSize = faker.datatype.number({ min: 10, max: 100 })
+      const chunkSize = faker.number.int({ min: 10, max: 100 })
       const chunk = bigJson.slice(index, index + chunkSize)
       chunks.push(chunk)
       index += chunkSize


### PR DESCRIPTION
## Description

This PR replaces the old `faker` library with the new community-driven `@faker-js/faker` library. The original `faker` library, once a popular choice for generating fake data, became unmaintained in January 2022. In response, the community came together to create `@faker-js/faker`, ensuring continued support and improvements. You can read more about this on our [website](https://fakerjs.dev/about/announcements/2022-01-14.html#i-heard-something-happened-what-s-the-tldr).

For transparency, I want to mention that I'm one of the maintainers of the new library.

We are actively seeking projects that still use the old library. By migrating these projects, we aim to prevent developers from inadvertently using outdated libraries when searching for code examples.

## Additional Infomation

I saw that you already had our library installed but were not activly using it. I upgraded the library to the latest version, migrated the mentions of `faker` and uninstalled the old library.

The additional changes in the `package-lock.json` seem to be due to previous desynchronization errors in the package files. 